### PR TITLE
New Modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ Just copy the `Backport.swift` file into your project. That’s it.
 
 | iOS Version | Modifier                                | Description                                      |
 |-------------|------------------------------------------|--------------------------------------------------|
-| iOS 17.0    | `backDeployedContentTransition(_:)`     | Applies numeric text content transitions         |
-| iOS 17.0    | `backDeployedDisfavoredLocations(_:for:)` | Sets widget disfavored locations               |
+| iOS 17.0    | `contentTransition(_:)`                 | Applies numeric text content transitions         |
+| iOS 17.0    | `disfavoredLocations(_:for:)`           | Sets widget disfavored locations                 |
 | iOS 18.0    | `presentationSizeForm()`                | Applies `.presentationSizing(.form)`            |
 | iOS 18.0    | `zoom(sourceID:in:)`                    | Applies a zoom navigation transition             |
 | iOS 18.0    | `matchedTransitionSource(id:in:)`       | Marks a view as a matched transition source      |
-| iOS 18.0    | `backDeployedWidgetAccentedRenderingMode(_:)` | Sets widget image accent rendering mode    |
+| iOS 18.0    | `widgetAccentedRenderingMode(_:)`       | Sets widget image accent rendering mode          |
 | iOS 18.1    | `imagePlayground(_:completion:)`        | Presents an image playground sheet               |
-| iOS 18.4    | `backDeployedImagePlaygroundSheet(isPresented:onCompletion:)` | Presents Image Playground sheet safely |
+| iOS 18.1    | `imagePlaygroundSheet(isPresented:onCompletion:)` | Presents Image Playground sheet            |
 | iOS 26.0    | `glassEffect(_:in:isEnabled:)`          | Applies a glass effect                           |
 | iOS 26.0    | `glassEffect(_:in:isEnabled:fallback:)`| Glass effect with fallback for unsupported OS    |
 | iOS 26.0    | `glassButtonStyle()`                    | Applies the glass button style                   |

--- a/README.md
+++ b/README.md
@@ -83,10 +83,14 @@ Just copy the `Backport.swift` file into your project. That’s it.
 
 | iOS Version | Modifier                                | Description                                      |
 |-------------|------------------------------------------|--------------------------------------------------|
+| iOS 17.0    | `backDeployedContentTransition(_:)`     | Applies numeric text content transitions         |
+| iOS 17.0    | `backDeployedDisfavoredLocations(_:for:)` | Sets widget disfavored locations               |
 | iOS 18.0    | `presentationSizeForm()`                | Applies `.presentationSizing(.form)`            |
 | iOS 18.0    | `zoom(sourceID:in:)`                    | Applies a zoom navigation transition             |
 | iOS 18.0    | `matchedTransitionSource(id:in:)`       | Marks a view as a matched transition source      |
+| iOS 18.0    | `backDeployedWidgetAccentedRenderingMode(_:)` | Sets widget image accent rendering mode    |
 | iOS 18.1    | `imagePlayground(_:completion:)`        | Presents an image playground sheet               |
+| iOS 18.4    | `backDeployedImagePlaygroundSheet(isPresented:onCompletion:)` | Presents Image Playground sheet safely |
 | iOS 26.0    | `glassEffect(_:in:isEnabled:)`          | Applies a glass effect                           |
 | iOS 26.0    | `glassEffect(_:in:isEnabled:fallback:)`| Glass effect with fallback for unsupported OS    |
 | iOS 26.0    | `glassButtonStyle()`                    | Applies the glass button style                   |

--- a/Sources/SwiftUIBackports/Backport+ContentTransition.swift
+++ b/Sources/SwiftUIBackports/Backport+ContentTransition.swift
@@ -1,0 +1,36 @@
+//
+//  BackDeployedContentTransition.swift
+//  SwiftUIBackports
+//
+//  Created by Ricky Witherspoon on 7/2/25.
+
+import SwiftUI
+
+public struct BackDeployedContentTransition {
+    let value: Double
+    
+    /// Creates a content transition intended to be used with `Text`
+    /// views displaying numeric text. In certain environments changes
+    /// to the text will enable a nonstandard transition tailored to
+    /// numeric characters that count up or down.
+    ///
+    /// - Returns: a new content transition.
+    public static func numericText(value: Double) -> Self {
+        return BackDeployedContentTransition(value: value)
+    }
+}
+
+public extension Backport where Content: View {
+    /// A back deployed version of `contentTransition`
+    ///
+    /// https://developer.apple.com/documentation/swiftui/view/contenttransition(_:)
+    @ViewBuilder func backDeployedContentTransition(_ transition: BackDeployedContentTransition) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+                .contentTransition(.numericText(value: transition.value))
+        } else {
+            content
+                .contentTransition(.numericText())
+        }
+    }
+}

--- a/Sources/SwiftUIBackports/Backport+ContentTransition.swift
+++ b/Sources/SwiftUIBackports/Backport+ContentTransition.swift
@@ -24,7 +24,7 @@ public extension Backport where Content: View {
     /// A back deployed version of `contentTransition`
     ///
     /// https://developer.apple.com/documentation/swiftui/view/contenttransition(_:)
-    @ViewBuilder func backDeployedContentTransition(_ transition: BackDeployedContentTransition) -> some View {
+    @ViewBuilder func contentTransition(_ transition: BackDeployedContentTransition) -> some View {
         if #available(iOS 17.0, *) {
             content
                 .contentTransition(.numericText(value: transition.value))

--- a/Sources/SwiftUIBackports/Backport+ImagePlaygroundSheet.swift
+++ b/Sources/SwiftUIBackports/Backport+ImagePlaygroundSheet.swift
@@ -23,7 +23,7 @@ import ImagePlayground
 /// - Returns: A view that conditionally presents the Image Playground sheet on supported OS versions.
 @MainActor
 public extension Backport where Content: View {
-    func backDeployedImagePlaygroundSheet(
+    func imagePlaygroundSheet(
         isPresented: Binding<Bool>,
         sourceImage: Image? = nil,
         onCompletion: @escaping (URL) -> Void,

--- a/Sources/SwiftUIBackports/Backport+ImagePlaygroundSheet.swift
+++ b/Sources/SwiftUIBackports/Backport+ImagePlaygroundSheet.swift
@@ -1,0 +1,42 @@
+//
+//  BackDeployedImagePlaygroundSheet.swift
+//  SwiftUIBackports
+//
+//  Created by Ricky Witherspoon on 7/2/25.
+
+import SwiftUI
+import ImagePlayground
+
+/// Presents the Image Playground sheet if the device is running iOS 18.1 or later.
+///
+/// This view modifier conditionally presents an AI image generation sheet using Apple's
+/// Image Playground framework. If the OS version is below iOS 18.1, the modifier has no effect.
+///
+/// Use this to back-deploy support for the Image Playground experience while maintaining compatibility
+/// with earlier OS versions.
+///
+/// - Parameters:
+///   - isPresented: A binding to a Boolean value that determines whether the sheet is presented.
+///   - sourceImage: An optional image that can be used as a starting point in the playground (currently unused).
+///   - onCompletion: A closure that is called with the generated image file URL when the user finishes the playground.
+///   - onCancellation: An optional closure that is called if the user cancels the playground experience.
+/// - Returns: A view that conditionally presents the Image Playground sheet on supported OS versions.
+@MainActor
+public extension Backport where Content: View {
+    func backDeployedImagePlaygroundSheet(
+        isPresented: Binding<Bool>,
+        sourceImage: Image? = nil,
+        onCompletion: @escaping (URL) -> Void,
+        onCancellation: (() -> Void)? = nil
+    ) -> some View {
+        if #available(iOS 18.1, *) {
+            return content.imagePlaygroundSheet(
+                isPresented: isPresented,
+                onCompletion: onCompletion,
+                onCancellation: onCancellation
+            )
+        } else {
+            return content
+        }
+    }
+}

--- a/Sources/SwiftUIBackports/Backport+WidgetAccentedRenderingMode.swift
+++ b/Sources/SwiftUIBackports/Backport+WidgetAccentedRenderingMode.swift
@@ -34,7 +34,7 @@ extension BackDeployedWidgetAccentedRenderingMode {
 
 public extension Backport where Content == Image {
     /// A back deployed method for `widgetAccentedRenderingMode` view modifier
-    func backDeployedWidgetAccentedRenderingMode(_ renderingMode: BackDeployedWidgetAccentedRenderingMode?) -> some View {
+    func widgetAccentedRenderingMode(_ renderingMode: BackDeployedWidgetAccentedRenderingMode?) -> some View {
         if #available(iOS 18.0, *) {
             return content
                 .widgetAccentedRenderingMode(renderingMode?.value)

--- a/Sources/SwiftUIBackports/Backport+WidgetAccentedRenderingMode.swift
+++ b/Sources/SwiftUIBackports/Backport+WidgetAccentedRenderingMode.swift
@@ -1,0 +1,45 @@
+//
+//  WidgetAccentedRenderingMode+BackDeploy.swift
+//  SwiftUIBackports
+//
+//  Created by Ricky Witherspoon on 7/2/25.
+
+import SwiftUI
+import WidgetKit
+
+/// A back deployed enum for `WidgetAccentedRenderingMode`
+public enum BackDeployedWidgetAccentedRenderingMode {
+    /// Specifies that the Image should be included as part of the accented widget group.
+    case accented
+    /// Maps the luminance of the Image in to the alpha channel, replacing color channels with the color applied to the default group.
+    case desaturated
+    /// Maps the luminance of the Image in to the alpha channel, replacing color channels with the color applied to the accent group.
+    case accentedDesaturated
+    /// Specifies that the Image should be rendered at full color with no other color modifications. Only applies to iOS.
+    case fullColor
+}
+
+@available(iOS 18.0, *)
+extension BackDeployedWidgetAccentedRenderingMode {
+    /// A back deployed method for `WidgetAccentedRenderingMode`
+    fileprivate var value: WidgetAccentedRenderingMode {
+        switch self {
+        case .accented: .accented
+        case .desaturated: .desaturated
+        case .accentedDesaturated: .accentedDesaturated
+        case .fullColor: .fullColor
+        }
+    }
+}
+
+public extension Backport where Content == Image {
+    /// A back deployed method for `widgetAccentedRenderingMode` view modifier
+    func backDeployedWidgetAccentedRenderingMode(_ renderingMode: BackDeployedWidgetAccentedRenderingMode?) -> some View {
+        if #available(iOS 18.0, *) {
+            return content
+                .widgetAccentedRenderingMode(renderingMode?.value)
+        } else {
+            return content
+        }
+    }
+}

--- a/Sources/SwiftUIBackports/Backport+WidgetConfiguration.swift
+++ b/Sources/SwiftUIBackports/Backport+WidgetConfiguration.swift
@@ -15,15 +15,15 @@ public enum WidgetDisfavoredLocation {
     case iPhoneWidgetsOnMac
 }
 
-extension WidgetConfiguration {
-    
+extension Backport where Content: WidgetConfiguration {
     /// A back deployed method for `disfavoredLocations`
-    public func backDeployedDisfavoredLocations(
+    @MainActor
+    public func disfavoredLocations(
         _ locations: [WidgetDisfavoredLocation],
         for families: [WidgetFamily]
     ) -> some WidgetConfiguration {
         if #available(iOS 17.0, *) {
-            return self.disfavoredLocations(
+            return content.disfavoredLocations(
                 locations.map { location in
                     switch location {
                     case .homeScreen:
@@ -39,7 +39,7 @@ extension WidgetConfiguration {
                 for: families
             )
         } else {
-            return self
+            return content
         }
     }
 }

--- a/Sources/SwiftUIBackports/Backport+WidgetConfiguration.swift
+++ b/Sources/SwiftUIBackports/Backport+WidgetConfiguration.swift
@@ -1,0 +1,45 @@
+//
+//  WidgetConfiguration+BackDeploy.swift
+//  SwiftUIBackports
+//
+//  Created by Ricky Witherspoon on 7/2/25.
+
+import SwiftUI
+import WidgetKit
+
+/// A back deployed version of  a`WidgetLocation` object
+public enum WidgetDisfavoredLocation {
+    case homeScreen
+    case lockScreen
+    case standBy
+    case iPhoneWidgetsOnMac
+}
+
+extension WidgetConfiguration {
+    
+    /// A back deployed method for `disfavoredLocations`
+    public func backDeployedDisfavoredLocations(
+        _ locations: [WidgetDisfavoredLocation],
+        for families: [WidgetFamily]
+    ) -> some WidgetConfiguration {
+        if #available(iOS 17.0, *) {
+            return self.disfavoredLocations(
+                locations.map { location in
+                    switch location {
+                    case .homeScreen:
+                        return .homeScreen
+                    case .lockScreen:
+                        return .lockScreen
+                    case .standBy:
+                        return .standBy
+                    case .iPhoneWidgetsOnMac:
+                        return .iPhoneWidgetsOnMac
+                    }
+                },
+                for: families
+            )
+        } else {
+            return self
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several back-deployment features to the SwiftUIBackports library, enabling compatibility for newer SwiftUI APIs on older iOS versions. The changes include new methods and enums for content transitions, image playground sheets, widget rendering modes, and widget disfavored locations.

### Back-deployment of SwiftUI features:

* **Content Transition**: Added `BackDeployedContentTransition` struct and `backDeployedContentTransition(_:)` view modifier to enable numeric text transitions on iOS 17.0 and earlier. (`Sources/SwiftUIBackports/Backport+ContentTransition.swift`, [Sources/SwiftUIBackports/Backport+ContentTransition.swiftR1-R36](diffhunk://#diff-da54729df89356c05f20f8416e9bc9cf102d56709454de0fc1a33f2d8f180aedR1-R36))
* **Image Playground Sheet**: Introduced `backDeployedImagePlaygroundSheet(isPresented:onCompletion:)` view modifier to conditionally present the Image Playground sheet on iOS 18.1 and earlier. (`Sources/SwiftUIBackports/Backport+ImagePlaygroundSheet.swift`, [Sources/SwiftUIBackports/Backport+ImagePlaygroundSheet.swiftR1-R42](diffhunk://#diff-efac2827653acf0e59804f3b377e0c11146c6710c44e19f7c1fabd9e7583387aR1-R42))
* **Widget Rendering Mode**: Added `BackDeployedWidgetAccentedRenderingMode` enum and `backDeployedWidgetAccentedRenderingMode(_:)` view modifier for backward compatibility with widget image accent rendering modes on iOS 18.0 and earlier. (`Sources/SwiftUIBackports/Backport+WidgetAccentedRenderingMode.swift`, [Sources/SwiftUIBackports/Backport+WidgetAccentedRenderingMode.swiftR1-R45](diffhunk://#diff-43cd07df68e3605bc3f5c91d357eabb9401a1a131c32d3098074ed655d2bb4e2R1-R45))
* **Widget Disfavored Locations**: Implemented `WidgetDisfavoredLocation` enum and `backDeployedDisfavoredLocations(_:for:)` method for supporting disfavored widget locations on iOS 17.0 and earlier. (`Sources/SwiftUIBackports/Backport+WidgetConfiguration.swift`, [Sources/SwiftUIBackports/Backport+WidgetConfiguration.swiftR1-R45](diffhunk://#diff-0bfd7253d3c542176998d14395d1084228a2f8935cadccca491867512ac92b8fR1-R45))

### Documentation updates:

* Updated `README.md` to include descriptions of the newly added back-deployment features for iOS 17.0, 18.0, and 18.1. (`README.md`, [README.mdR86-R93](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86-R93))