### PR TITLE
feat: allow fallback button style with glassButtonStyle

### DIFF
--- a/Sources/SwiftUIBackports/SwiftUIBackports.swift
+++ b/Sources/SwiftUIBackports/SwiftUIBackports.swift
@@ -255,11 +255,11 @@ public extension Backport where Content: View {
             }
         }
     
-    @ViewBuilder func glassButtonStyle() -> some View {
+    @ViewBuilder func glassButtonStyle(fallbackStyle: some PrimitiveButtonStyle = DefaultButtonStyle()) -> some View {
         if #available(iOS 26.0, *) {
             content.buttonStyle(.glass)
         } else {
-            content
+            content.buttonStyle(fallbackStyle)
         }
     }
 


### PR DESCRIPTION
Sometimes, a fallback style is needed when using `glassButtonStyle` (ie. `.bordered`). This PR allows passing that instead of adding another `.buttonStyle` modifier after this one for older OSes.